### PR TITLE
モバイルで右側に空白が出来る問題を修正

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,11 +155,10 @@ a:hover {
         align-items: center;
     }
     .portfolio-app-box a {
-        padding-bottom: 20px;
-        width: 800px;
+        margin-bottom: 20px;
     }
     .portfolio-app-box img {
-        width: 800px;
+        max-width: 45%;
     }
 }
 


### PR DESCRIPTION
worksの写真リンクにwidth: 800pxを指定しているせいで、モバイルだと右側に余計な空白が出てしまっているのを修正しました。